### PR TITLE
Drop offs w/out polling locations isn't an error

### DIFF
--- a/civic_api/fixtures/civic_api_fixtures.go
+++ b/civic_api/fixtures/civic_api_fixtures.go
@@ -32,6 +32,12 @@ func MakeRequestSuccessWithDropOff(endpoint string) ([]byte, error) {
 	return data, nil
 }
 
+func MakeRequestSuccessNoPollingLocationsWithDropOff(endpoint string) ([]byte, error) {
+	data, _ := ioutil.ReadFile(path.Join(root, "google_civic_success_no_polling_location_with_drop_off.json"))
+
+	return data, nil
+}
+
 func MakeRequestSuccessEmpty(endpoint string) ([]byte, error) {
 	data, _ := ioutil.ReadFile(path.Join(root, "google_civic_success_empty.json"))
 

--- a/civic_api/fixtures/google_civic_success_no_polling_location_with_drop_off.json
+++ b/civic_api/fixtures/google_civic_success_no_polling_location_with_drop_off.json
@@ -1,0 +1,132 @@
+{
+ "kind": "civicinfo#voterInfoResponse",
+ "election": {
+  "id": "4100",
+  "name": "US General Election 2014",
+  "electionDay": "2014-11-04"
+ },
+ "normalizedInput": {
+  "line1": "100 n main st",
+  "city": "providence",
+  "state": "RI",
+  "zip": "02903"
+ },
+ "dropOffLocations": [
+  {
+   "address": {
+    "locationName": "PROVIDENCE LIBRARY - GUTENBERG BRANCH",
+    "line1": "14 40TH ST",
+    "city": "PROVIDENCE",
+    "state": "RI",
+    "zip": "02906"
+   },
+   "notes": "",
+   "pollingHours": "7am - 7pm",
+   "sources": [
+    {
+     "name": "Voting Information Project",
+     "official": true
+    }
+   ]
+  }
+ ],
+ "contests": [
+  {
+   "type": "General Election",
+   "special": "no",
+   "office": "SENATOR IN GENERAL ASSEMBLY DIST 06",
+   "district": {
+    "name": "STATE SENATE",
+    "scope": "stateUpper",
+    "id": "6"
+   },
+   "ballotPlacement": "14",
+   "candidates": [
+    {
+     "name": "HAROLD METTS",
+     "party": "Democrat",
+     "phone": "4012720112"
+    },
+    {
+     "name": "RUSSELL HRYZAN",
+     "party": "Independent"
+    }
+   ],
+   "sources": [
+    {
+     "name": "Voting Information Project",
+     "official": true
+    }
+   ]
+  },
+  {
+   "type": "General Election",
+   "special": "no",
+   "office": "REPRESENTATIVE IN GENERAL ASSEMBLY DIST 01",
+   "district": {
+    "name": "STATE REP",
+    "scope": "stateLower",
+    "id": "1"
+   },
+   "ballotPlacement": "47",
+   "candidates": [
+    {
+     "name": "EDITH AJELLO",
+     "party": "Democrat",
+     "phone": "4012747078"
+    }
+   ],
+   "sources": [
+    {
+     "name": "Voting Information Project",
+     "official": true
+    }
+   ]
+  }
+ ],
+ "state": [
+  {
+   "name": "Rhode Island",
+   "local_jurisdiction": {
+    "name": "PROVIDENCE",
+    "electionAdministrationBody": {
+     "name": "MRS CLAUDIA J HAUGEN",
+     "electionInfoUrl": "http://www.sos.ri.gov",
+     "electionRegistrationUrl": "http://www.sos.ri.gov/elections/voters/register/",
+     "electionRegistrationConfirmationUrl": "https://sos.ri.gov/vic/",
+     "absenteeVotingInfoUrl": "https://sos.ri.gov/elections/voters/mail/",
+     "votingLocationFinderUrl": "https://sos.ri.gov/vic/",
+     "electionRulesUrl": "https://sos.ri.gov/elections/electionlaws/",
+     "hoursOfOperation": "8:30a-4:30p (daily) 7a-9p (election day)",
+     "physicalAddress": {
+      "line1": "25 DORRANCE STREET",
+      "city": "PROVIDENCE",
+      "state": "RI",
+      "zip": "02903"
+     },
+     "electionOfficials": [
+       {
+        "name": "Dan Burk",
+        "title": "Registrar of Voters",
+        "officePhoneNumber": "(775) 328-3670",
+        "faxNumber": "(775) 328-3747",
+        "emailAddress": "dburk@washoecounty.us"
+       }
+      ]
+    },
+    "sources": [
+     {
+      "name": "Voting Information Project",
+      "official": true
+     }
+    ]
+   },
+   "sources": [
+    {
+     "name": "Voting Information Project",
+     "official": true
+    }
+   ]
+  }
+ ]
+}

--- a/response_generator/polling_location/polling_location_test.go
+++ b/response_generator/polling_location/polling_location_test.go
@@ -237,6 +237,22 @@ func TestPollingLocationEmpty(t *testing.T) {
 	assert.Equal(t, expected, g.Generate("+15551235555", "111 address street", 0))
 }
 
+func TestPollingLocationEmptyButHasDropOffLocations(t *testing.T) {
+	setup()
+	s := fakeStorage.New()
+	u := users.New(s)
+
+	c := civicApi.New("", "", "", civicApiFixtures.MakeRequestSuccessNoPollingLocationsWithDropOff)
+	g := responseGenerator.New(c, u)
+
+	expected := []string{
+		fmt.Sprintf("%s\nPROVIDENCE LIBRARY - GUTENBERG BRANCH\n14 40TH ST\nPROVIDENCE, RI 02906\n%s 7am - 7pm", content.DropOffLocation.Text["en"]["prefix"], content.DropOffLocation.Text["en"]["hours"]),
+		content.Help.Text["en"]["menu"],
+		content.Help.Text["en"]["languages"]}
+
+	assert.Equal(t, expected, g.Generate("+15551235555", "111 address street", 0))
+}
+
 func TestPollingLocationFailure(t *testing.T) {
 	setup()
 	s := fakeStorage.New()


### PR DESCRIPTION
If the Google Civic API returns drop off locations and no polling locations, respond with a drop off location instead of a message about not finding any election information for the address.

Check the [diff without whitespace changes](https://github.com/votinginfoproject/sms-worker/pull/10/files?w=1#diff-7089a729092d0e260c808cb5942901a5L21) to see how the change to `success` in polling_location.go is moving some code into an `if`.
