### PR TITLE
Add electionInfoUrl to "official" response

### DIFF
--- a/civic_api/civic_api.go
+++ b/civic_api/civic_api.go
@@ -56,6 +56,7 @@ type Response struct {
 					OfficePhoneNumber string `json:"officePhoneNumber"`
 					EmailAddress      string `json:"emailAddress"`
 				} `json:"electionOfficials"`
+				ElectionInfoUrl   string `json:"electionInfoUrl"`
 				ElectionRegistrationUrl string `json:"electionRegistrationUrl"`
 			} `json:"electionAdministrationBody"`
 		} `json:"local_jurisdiction"`

--- a/response_generator/elo/elo.go
+++ b/response_generator/elo/elo.go
@@ -6,7 +6,7 @@ import (
 )
 
 func BuildMessage(res *civicApi.Response, language string, content *responses.Content) []string {
-	name, email, phone := getElo(res)
+	name, email, phone, url := getElo(res)
 	if len(name) == 0 {
 		return []string{content.Errors.Text[language]["noElectionOfficial"]}
 	}
@@ -20,10 +20,14 @@ func BuildMessage(res *civicApi.Response, language string, content *responses.Co
 		message = message + "\n" + content.Elo.Text[language]["email"] + " " + email
 	}
 
+	if len(url) > 0 {
+		message = message + "\n" + url
+	}
+
 	return []string{message}
 }
 
-func getElo(res *civicApi.Response) (string, string, string) {
+func getElo(res *civicApi.Response) (string, string, string, string) {
 	defer func() {
 		if err := recover(); err != nil {
 		}
@@ -32,12 +36,15 @@ func getElo(res *civicApi.Response) (string, string, string) {
 	var name string
 	var email string
 	var phone string
+	var url string
 
-	elo := res.State[0].LocalJurisdiction.ElectionAdministrationBody.ElectionOfficials[0]
+	eab := res.State[0].LocalJurisdiction.ElectionAdministrationBody
+	elo := eab.ElectionOfficials[0]
 
 	name = elo.Name
 	email = elo.EmailAddress
 	phone = elo.OfficePhoneNumber
+	url = eab.ElectionInfoUrl
 
-	return name, email, phone
+	return name, email, phone, url
 }

--- a/response_generator/elo/elo_test.go
+++ b/response_generator/elo/elo_test.go
@@ -78,6 +78,6 @@ func TestEloSuccessExistingUser(t *testing.T) {
 	c := civicApi.New("", "", "", civicApiFixtures.MakeRequestSuccess)
 	g := responseGenerator.New(c, u)
 
-	expected := []string{"Your local election official is:\nDan Burk\nPhone: (775) 328-3670\nEmail: dburk@washoecounty.us"}
+	expected := []string{"Your local election official is:\nDan Burk\nPhone: (775) 328-3670\nEmail: dburk@washoecounty.us\nhttp://www.sos.ri.gov"}
 	assert.Equal(t, expected, g.Generate("+15551235555", "elo", 0))
 }


### PR DESCRIPTION
There aren't translations for what to display before the url (like "Website:" or something), so this puts the url alone on its own line (which might be okay).

![screenshot_20160914-153704](https://cloud.githubusercontent.com/assets/3526/18527992/130c4062-7a95-11e6-8187-fbf5d7c0f5ef.png)

Pivotal story: [129856347](https://www.pivotaltracker.com/story/show/129856347)
