### PR TITLE
Spanish language fix

### DIFF
--- a/data/raw/data.yml
+++ b/data/raw/data.yml
@@ -222,6 +222,7 @@ changeLanguage:
     es:
       - español
       - espanol
+      - español
     jp:
       - 日本語
     cn:

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,14 @@ $ docker run sms-worker
 godep go test ./...
 ~~~~
 
+To run the tests in docker:
+
+- `docker build -t sms-worker .` to build the Docker image
+- `docker run -ti --env-file .env sms-worker /bin/bash` to start the
+container with an interactive terminal
+- `godep go test ./...` to run the tests.
+
+
 ### Generate Go Data File From YAML
 ~~~~
 go-bindata -prefix "data" -pkg "data" -o data/data.go data/raw

--- a/response_generator/change_language/change_language_test.go
+++ b/response_generator/change_language/change_language_test.go
@@ -38,6 +38,22 @@ func TestChangeLanguageWithLanguageCommandNotFirstContact(t *testing.T) {
 	assert.Equal(t, expected, g.Generate("+15551235555", "español", 0))
 }
 
+func TestChangeLanguageWithLanguageCommandNotFirstContactSpanish(t *testing.T) {
+	setup()
+	s := fakeStorage.New()
+	u := users.New(s)
+
+	time := time.Now().Unix()
+	timeString := strconv.FormatInt(time, 10)
+	s.CreateItem("+15551235555", map[string]string{"language": "en", "last_contact": timeString})
+
+	c := civicApi.New("", "", "", civicApiFixtures.MakeRequestSuccessFake)
+	g := responseGenerator.New(c, u)
+
+	expected := []string{content.Help.Text["es"]["intro"], content.Help.Text["es"]["languages"]}
+	assert.Equal(t, expected, g.Generate("+15551235555", "español", 0))
+}
+
 func TestChangeLanguageWithOtherCommandNotFirstContact(t *testing.T) {
 	setup()
 	s := fakeStorage.New()


### PR DESCRIPTION
We determined recently (per [this card](https://www.pivotaltracker.com/story/show/151854203)) that when using a standard phone keyboard to type `español` that the SMS app wasn't accepting it as a trigger to change the language to Spanish.  While the difference is hard to see, what we ended up doing to fix it was to copy and paste the way that `español` was coming through in the SMS messages in question (via the Twilio logs) and add that as an option in `data/raw/data.yml` to trigger changing the language to Spanish.  I also added another test in `response_generator/change_language/change_language_test.go` using the copy-pasted version of `español` to confirm the language change there as well.  

If any other languages are found to not work in a similar way, adding whatever comes through to Twilio in the `data.yml` file should similarly fix it.

Additionally, I added some instructions on running the tests via docker.